### PR TITLE
Renamed 'imu' class to 'IMU'

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -12,7 +12,7 @@
 #include "sensors/imu/imu.h"
 #include "utils/utils.h"
 
-imu imu;
+IMU imu;
 Attitude attitude;
 
 void setup()

--- a/main/sensors/imu/gy521.cxx
+++ b/main/sensors/imu/gy521.cxx
@@ -14,7 +14,7 @@
 const uint8_t MPU=0x68;                  //I2C address of the MPU-6050
 const double tcal = -1600;           //Temperature correction
 
-imuReading imu::sample()
+imuReading IMU::sample()
 {
   imuReading imuSample;
   imuSample.time = micros(); //current timestamp
@@ -54,7 +54,7 @@ imuReading imu::sample()
  * 
  * Verify that the connection is operating properly by taking a sample.
  */
-void imu::setup(){ 
+void IMU::setup(){ 
   XBeeSerial.print("Setting up GY521 IMU... ");
   
   Wire.beginTransmission(MPU);  //This is the I2C address of the MPU (b1101000/b1101001 for AC0 low/high datasheet sec. 9.2)
@@ -73,7 +73,7 @@ void imu::setup(){
   Wire.endTransmission();
 
   delay(3000);                  // This delay allows time for the IMU setup to be completed before reading values.
-  imuReading sample = imu::sample(); // Reads 1 sample of data from IMU.
+  imuReading sample = IMU::sample(); // Reads 1 sample of data from IMU.
 
   if(sample.accel.x != 0 || sample.accel.y != 0 || sample.accel.z != 0)
     XBeeSerial.println("IMU setup successful.");

--- a/main/sensors/imu/imu.h
+++ b/main/sensors/imu/imu.h
@@ -8,7 +8,7 @@
 #include "../../utils/datatypes.h"
 
 // Interface for IMU functions
-class imu
+class IMU
 {
     public:
     /**

--- a/main/sensors/imu/lsm6dsox.cxx
+++ b/main/sensors/imu/lsm6dsox.cxx
@@ -18,7 +18,7 @@ Adafruit_LSM6DSOX sox;
  * 
  * @return imuReading 
  */
-imuReading imu::sample() {
+imuReading IMU::sample() {
     imuReading imuSample;
     imuSample.time = micros(); //current timestamp
 
@@ -44,7 +44,7 @@ imuReading imu::sample() {
     return imuSample; //return gyro and accel data
 }
 
-void imu::setup() {
+void IMU::setup() {
     XBeeSerial.print("Setting up IMU... ");
 
     if (!sox.begin_SPI(IMU_CS, SPI1_SCK, SPI1_MISO, SPI1_MOSI)) {


### PR DESCRIPTION
<!-- Please Give Your PR a relevant title-->

## Description of Problem
<!-- Clearly describe the problem you're solving-->
<!---- What exactly are you fixing?----->
'imu' class conflicts with variable of same name.

## Solution
<!-- Describe your thought process and the steps you took to find a solution. If your process resulted in a new issue being created, link it here-->
Changed to 'IMU' to fix issue, increase readability and follow naming conventions.

## Testing
<!-- Describe the testing that you did to validate your changes (i.e. ran a unit test, loaded onto physical microcontroller etc.)-->
<!-- ex:
- Executed "throw test" on Catalyst to verify behavior
-->

## Logs
<!-- If your testing generated relevant log files, please paste them here
You should surround any multiline logs with triple backticks (```) so that they'll be formatted properly-->
<!-- NOTE: Compilation logs are not necessary, they will be automatically generated>

## Issues
<!-- link any issues here using the linking key words-->
<!-- ex: This line will automatically close issue #100 when your code is merged
closes #100
-->
