### PR TITLE
131 include units in var names

### DIFF
--- a/main/apogee.h
+++ b/main/apogee.h
@@ -43,7 +43,7 @@ bool detectLaunch(Directional accel){//accel in Gs
  * @return false rocket is not accelerating substantially
  */
 bool isAccelerating(Directional accel){//determine if we are accelerating at more than 2 Gs
-  return sqrt(pow(accel.x, 2) + pow(accel.y, 2) + pow(accel.z, 2)) > MAX_APOGEE_ACCEL;
+  return sqrt(pow(accel.x, 2) + pow(accel.y, 2) + pow(accel.z, 2)) > MAX_APOGEE_ACCEL_G;
 }
 
 /**

--- a/main/apogee.h
+++ b/main/apogee.h
@@ -25,10 +25,10 @@ bool detectLaunch(Directional accel){//accel in Gs
 
   //group all accels into one
   //accel may need calibration. If that is the case, it should happen externally and only calibrated data should enter this function
-  double totalAccel = sqrt(pow(accel.x, 2) + pow(accel.y, 2) + pow(accel.z, 2)); //this should be 1G when stationary
-  accelFilter.filter(totalAccel);
-  double filteredAccel = accelFilter.getOutput();
-  if(filteredAccel > G_FORCE_TO_LAUNCH)
+  double totalAccelg = sqrt(pow(accel.x, 2) + pow(accel.y, 2) + pow(accel.z, 2)); //this should be 1G when stationary
+  accelFilter.filter(totalAccelg);
+  double filteredAccelg = accelFilter.getOutput();
+  if(filteredAccelg > G_FORCE_TO_LAUNCH)
     hasLaunched = true;
   return hasLaunched;
 }

--- a/main/config/config.h
+++ b/main/config/config.h
@@ -19,6 +19,6 @@
 #include "config/catalyst2.h"
 #endif
 
-constexpr double MAIN_ALTITUDEm = 200; //altitude to deploy main parachute at (meters)
+constexpr double MAIN_ALTITUDE_M = 200; //altitude to deploy main parachute at (meters)
 constexpr double G_FORCE_TO_LAUNCH = 2; //if acceleration exceeds this number the rocket will assume it has been launched
-constexpr double MAX_APOGEE_ACCELg = 1; //we can rule out apogee if acceleration is above this amount (Gs)
+constexpr double MAX_APOGEE_ACCEL_G = 1; //we can rule out apogee if acceleration is above this amount (Gs)

--- a/main/config/config.h
+++ b/main/config/config.h
@@ -19,6 +19,6 @@
 #include "config/catalyst2.h"
 #endif
 
-constexpr double MAIN_ALTITUDE = 200; //altitude to deploy main parachute at (meters)
+constexpr double MAIN_ALTITUDEm = 200; //altitude to deploy main parachute at (meters)
 constexpr double G_FORCE_TO_LAUNCH = 2; //if acceleration exceeds this number the rocket will assume it has been launched
-constexpr double MAX_APOGEE_ACCEL = 1; //we can rule out apogee if acceleration is above this amount (Gs)
+constexpr double MAX_APOGEE_ACCELg = 1; //we can rule out apogee if acceleration is above this amount (Gs)

--- a/main/main.ino
+++ b/main/main.ino
@@ -184,7 +184,7 @@ flightPhase runDescending(uint32_t tick){//this runs at 20hz
   static double altForVelocity = bmpSample.altitude;
   double currentVelocity = (altForVelocity - bmpSample.altitude) * 20; //delta alt divided by dt (.05)
 
-  if ((bmpSample.altitude < MAIN_ALTITUDE || currentVelocity > 50) && !deployedMain) {
+  if ((bmpSample.altitude < MAIN_ALTITUDE_M || currentVelocity > 50) && !deployedMain) {
     digitalWrite(PYRO0_PIN, HIGH);
     delay(1000);
     digitalWrite(PYRO0_PIN, LOW);

--- a/main/sensors/altimeter/bmp3xx.h
+++ b/main/sensors/altimeter/bmp3xx.h
@@ -35,12 +35,12 @@ bmpReading getBMP()
 }
 
 void setGroundLevelPressure() { //Reads bmp data and sets ground lvl pressure
-  double pressurePreFlight;
+  double pressurePreFlight_hPa;
   double pressureSum = 0;  //Sum of 100 pressure readings
   for(int i = 0; i<100; i++){
     bmp.performReading();
-    pressurePreFlight = bmp.pressure / 100.0; //sample pressure in hPa
-    pressureSum += pressurePreFlight;
+    pressurePreFlight_hPa = bmp.pressure / 100.0; //sample pressure in hPa
+    pressureSum += pressurePreFlight_hPa;
   }
   GNDLEVELPRESSURE_HPA = pressureSum / 100.0; //sets average ground lvl pressure
 }

--- a/main/sensors/imu/lsm6dsox.cxx
+++ b/main/sensors/imu/lsm6dsox.cxx
@@ -22,24 +22,24 @@ imuReading imu::sample() {
     imuReading imuSample;
     imuSample.time = micros(); //current timestamp
 
-    sensors_event_t accel;
-    sensors_event_t gyro;
-    sensors_event_t temp;
+    sensors_event_t accelg;
+    sensors_event_t gyroRad;
+    sensors_event_t tempC;
 
-    sox.getEvent(&accel, &gyro, &temp);
+    sox.getEvent(&accelg, &gyroRad, &tempC);
 
     // convert acceleration data from m/s^2 to Gs
     // TODO: axis mapping should be controlled in config files (Z is up, Y and X are arbitrary for now)
-    imuSample.accel.x = accel.acceleration.x / 9.81;
-    imuSample.accel.z = accel.acceleration.y / 9.81;
-    imuSample.accel.y = accel.acceleration.z / 9.81;
+    imuSample.accelg.x = accelg.acceleration.x / 9.81;
+    imuSample.accelg.z = accelg.acceleration.y / 9.81;
+    imuSample.accelg.y = accelg.acceleration.z / 9.81;
 
     // TODO: axis mapping should be controlled in config files (Z is up, Y and X are arbitrary for now)
-    imuSample.gyro.x = gyro.gyro.x;
-    imuSample.gyro.z = gyro.gyro.y;
-    imuSample.gyro.y = gyro.gyro.z;
+    imuSample.gyroRad.x = gyroRad.gyro.x;
+    imuSample.gyroRad.z = gyroRad.gyro.y;
+    imuSample.gyroRad.y = gyroRad.gyro.z;
 
-    (void) temp; //we can remove this if we decide to record temperature from the IMU
+    (void) tempC; //we can remove this if we decide to record temperature from the IMU
 
     return imuSample; //return gyro and accel data
 }

--- a/main/sensors/imu/lsm6dsox.cxx
+++ b/main/sensors/imu/lsm6dsox.cxx
@@ -22,17 +22,17 @@ imuReading imu::sample() {
     imuReading imuSample;
     imuSample.time = micros(); //current timestamp
 
-    sensors_event_t accelg;
+    sensors_event_t accel_ms2;
     sensors_event_t gyroRad;
     sensors_event_t tempC;
 
-    sox.getEvent(&accelg, &gyroRad, &tempC);
+    sox.getEvent(&accel_ms2, &gyroRad, &tempC);
 
     // convert acceleration data from m/s^2 to Gs
     // TODO: axis mapping should be controlled in config files (Z is up, Y and X are arbitrary for now)
-    imuSample.accelg.x = accelg.acceleration.x / 9.81;
-    imuSample.accelg.z = accelg.acceleration.y / 9.81;
-    imuSample.accelg.y = accelg.acceleration.z / 9.81;
+    imuSample.accel_ms2.x = accel_ms2.acceleration.x / 9.81;
+    imuSample.accel_ms2.z = accel_ms2.acceleration.y / 9.81;
+    imuSample.accel_ms2.y = accel_ms2.acceleration.z / 9.81;
 
     // TODO: axis mapping should be controlled in config files (Z is up, Y and X are arbitrary for now)
     imuSample.gyroRad.x = gyroRad.gyro.x;

--- a/main/sensors/imu/lsm6dsox.cxx
+++ b/main/sensors/imu/lsm6dsox.cxx
@@ -30,9 +30,9 @@ imuReading imu::sample() {
 
     // convert acceleration data from m/s^2 to Gs
     // TODO: axis mapping should be controlled in config files (Z is up, Y and X are arbitrary for now)
-    imuSample.accel_ms2.x = accel_ms2.acceleration.x / 9.81;
-    imuSample.accel_ms2.z = accel_ms2.acceleration.y / 9.81;
-    imuSample.accel_ms2.y = accel_ms2.acceleration.z / 9.81;
+    imuSample.accel_g.x = accel_ms2.acceleration.x / 9.81;
+    imuSample.accel_g.z = accel_ms2.acceleration.y / 9.81;
+    imuSample.accel_g.y = accel_ms2.acceleration.z / 9.81;
 
     // TODO: axis mapping should be controlled in config files (Z is up, Y and X are arbitrary for now)
     imuSample.gyroRad.x = gyroRad.gyro.x;

--- a/sensor-testing/BMP_388/BMP_388.ino
+++ b/sensor-testing/BMP_388/BMP_388.ino
@@ -76,5 +76,5 @@ void getBMP()
   }
   temperature_C = bmp.temperature;          // Temperature in Celcius
   pressure_hPa = bmp.pressure / 100.0;        // Pressure in hPa
-  Altitude_m = bmp.readAltitude(SEALEVELPRESSURE_HPA) - altOffset; // Approximate altitude in meters
+  Altitude_m = bmp.readAltitude(SEALEVELPRESSURE_HPA) - altOffset_m; // Approximate altitude in meters
 }

--- a/sensor-testing/BMP_388/BMP_388.ino
+++ b/sensor-testing/BMP_388/BMP_388.ino
@@ -14,7 +14,7 @@
 
 #define SEALEVELPRESSURE_HPA (1013.25)
 
-double Altitude, temperature, pressure, altOffset = 0;
+double Altitude_m, temperature_C, pressure_hPa, altOffset_m = 0;
 
 Adafruit_BMP3XX bmp;
 
@@ -28,23 +28,23 @@ void setup() {
   for(int i = 0; i < 100; i++)
   {
     getBMP();
-    total += Altitude;
+    total += Altitude+m;
   }
-  altOffset = total/100.0;
+  altOffset_m = total/100.0;
 }
 
 void loop() {
   getBMP();
   Serial.print("Temperature = ");
-  Serial.print(temperature);
+  Serial.print(temperature_C);
   Serial.println(" *C");
 
   Serial.print("Offset = ");
-  Serial.print(altOffset);
+  Serial.print(altOffset_m);
   Serial.println(" m");
 
   Serial.print("Altitude = ");
-  Serial.print(Altitude);
+  Serial.print(Altitude_m);
   Serial.println(" m");
 
   delay(100);
@@ -74,7 +74,7 @@ void getBMP()
     Serial.println("Failed to perform BMP388 reading.");
     return;
   }
-  temperature = bmp.temperature;          // Temperature in Celcius
-  pressure = bmp.pressure / 100.0;        // Pressure in hPa
-  Altitude = bmp.readAltitude(SEALEVELPRESSURE_HPA) - altOffset; // Approximate altitude in meters
+  temperature_C = bmp.temperature;          // Temperature in Celcius
+  pressure_hPa = bmp.pressure / 100.0;        // Pressure in hPa
+  Altitude_m = bmp.readAltitude(SEALEVELPRESSURE_HPA) - altOffset; // Approximate altitude in meters
 }

--- a/test/lib/mock_arduino.h
+++ b/test/lib/mock_arduino.h
@@ -52,8 +52,8 @@ public:
         (void)setting;
     }
 
-    double pressure;
-    double temperature;
+    double pressurekPa;
+    double temperatureC;
 
 };
 

--- a/test/lib/mock_arduino.h
+++ b/test/lib/mock_arduino.h
@@ -13,8 +13,8 @@ class Adafruit_BMP3XX
 {
 public:
     bool performReading() {
-        pressurekPa = 100;
-        temperatureC = 1;
+        pressure = 100;
+        temperature = 1;
         return true;
     }
 
@@ -52,8 +52,8 @@ public:
         (void)setting;
     }
 
-    double pressurekPa;
-    double temperatureC;
+    double pressure;
+    double temperature;
 
 };
 

--- a/test/lib/mock_arduino.h
+++ b/test/lib/mock_arduino.h
@@ -13,8 +13,8 @@ class Adafruit_BMP3XX
 {
 public:
     bool performReading() {
-        pressure = 100;
-        temperature = 1;
+        pressurekPa = 100;
+        temperatureC = 1;
         return true;
     }
 


### PR DESCRIPTION
Include Units within Variable Names

## Description of Problem
The problem being solved is having variables that do not reference the unit being used.

## Solution
I went through every file within Stimulant and parsed through the code looking for variables to rename. 


## Issues
I have some concerns on whether some code should be left untouched as I could have changed names in places that are probably referencing some function or value within the respective sensor
